### PR TITLE
hash import --> @import

### DIFF
--- a/Generate GIF/Loop 100 ms.sketchplugin
+++ b/Generate GIF/Loop 100 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -l -d 10 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Loop 1000 ms.sketchplugin
+++ b/Generate GIF/Loop 1000 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -l -d 100 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Loop 200 ms.sketchplugin
+++ b/Generate GIF/Loop 200 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+#@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -l -d 20 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Loop 2000 ms.sketchplugin
+++ b/Generate GIF/Loop 2000 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -l -d 200 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Loop 500 ms.sketchplugin
+++ b/Generate GIF/Loop 500 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -l -d 50 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Loop 5000 ms.sketchplugin
+++ b/Generate GIF/Loop 5000 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -l -d 500 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Loop No Delay.sketchplugin
+++ b/Generate GIF/Loop No Delay.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -l -d 0 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Once 100 ms.sketchplugin
+++ b/Generate GIF/Once 100 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -d 10 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Once 1000 ms.sketchplugin
+++ b/Generate GIF/Once 1000 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -d 100 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Once 200 ms.sketchplugin
+++ b/Generate GIF/Once 200 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -d 20 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Once 2000 ms.sketchplugin
+++ b/Generate GIF/Once 2000 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -d 200 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Once 500 ms.sketchplugin
+++ b/Generate GIF/Once 500 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -d 50 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Once 5000 ms.sketchplugin
+++ b/Generate GIF/Once 5000 ms.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -d 500 '*.png.gif' -o \"" + gifPath + "\"' \\;")

--- a/Generate GIF/Once No Delay.sketchplugin
+++ b/Generate GIF/Once No Delay.sketchplugin
@@ -1,3 +1,3 @@
-#import 'plugin.js'
+@import 'plugin.js'
 
 plugin("find \"" + gifsetPath + "\" -name '*.png.gif' -execdir bash -c '\"" + gifx + "\" -d 0 '*.png.gif' -o \"" + gifPath + "\"' \\;")


### PR DESCRIPTION
`#import` is deprecated in favor of `@import`.

Also adds newlines at the end of files. Atom did this automatically but should be done anyway.